### PR TITLE
D8CORE-1468-IE-fix: fix flex rule for IE

### DIFF
--- a/css/react_paragraphs.field_formatter.css
+++ b/css/react_paragraphs.field_formatter.css
@@ -63,4 +63,4 @@
 .react-paragraphs-row [data-react-columns="12"] {
   -webkit-box-flex: 12;
       -ms-flex: 12 1 0px;
-          flex: 12 1 0; }
+          flex: 12 1 auto; }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
Not all flex rules work for IE. This change appears to work on IE, Edge, Chrome, and Firefox

I wonder if we need to replicate this for the other related flex rules in this file?

# Review By (Date)
- Soonish. 

# Urgency
- It makes full with pages readable on IE.


# Steps to Test
Because my local environment is AWOL, I'm not able to verify this works in code.

1. Pull this branch
2. Rebuild as necessary
3. Maximize the browser viewport.
3. Verify correct homepage layout on IE, Edge, Chrome, and Firefox
4. Verify any full width page displays as expected.

# Affected Projects or Products
- D8Core

# Associated Issues and/or People
- JIRA ticket: https://stanfordits.atlassian.net/browse/D8CORE-1468

- Any other contextual information that might be helpful (e.g., description of a bug that this PR fixes, new functionality that it adds, etc.)
- Anyone who should be notified? (`@mention` them here)

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
