### PR TITLE
D8CORE-000: Use altered widget values for viewfield.

### DIFF
--- a/src/Plugin/Field/ReactParagraphsFields/View.php
+++ b/src/Plugin/Field/ReactParagraphsFields/View.php
@@ -51,36 +51,29 @@ class View extends ReactParagraphsFieldsBase {
    */
   public function getFieldInfo(array $field_element, FieldConfigInterface $field_config) {
     $info = parent::getFieldInfo($field_element, $field_config);
-    $info['displays'] = [];
     $info['views'] = [];
+    $info['displays'] = [];
+    $widget = $field_element['widget'][0];
+    unset($widget['target_id']['#options']['_none']);
 
-    $view_storage = $this->entityTypeManager->getStorage('view');
-    $view_options = $field_element['widget'][0]['target_id']['#options'];
-    $allowed_displays = array_filter($field_config->getSetting('allowed_display_types'));
+    $allowed_views_keys = array_keys($widget['target_id']['#options']);
+    $allowed_views_values = array_values($widget['target_id']['#options']);
+    $allowed_displays = $widget['display_id']['#options'];
 
-    /** @var \Drupal\views\ViewEntityInterface $view */
-    foreach ($view_storage->loadMultiple(array_keys($view_options)) as $view) {
-      $displays = $view->get('display');
-      $valid_displays = FALSE;
+    // TODO: Get these default values working.
+    // $info['defaultValue']['views'] = $widget['target_id']['#default_value'];
+    // $info['defaultValue']['displays'] = $widget['display_id']['#default_value'];
 
-      foreach ($displays as $display_id => $display) {
-        // The field only allows certain display modes. Don't allow those
-        // displays from being available to the user.
-        if ($allowed_displays && !in_array($display['display_plugin'], $allowed_displays)) {
-          continue;
-        }
+    foreach ($allowed_views_keys as $i => $v) {
+      $info['views'][] = [
+        'value' => $allowed_views_keys[$i],
+        'label' => $allowed_views_values[$i],
+      ];
 
-        $valid_displays = TRUE;
-        $info['displays'][$view->id()][] = [
-          'value' => $display_id,
-          'label' => $display['display_title'],
-        ];
-      }
-
-      if ($valid_displays) {
-        $info['views'][] = [
-          'value' => $view->id(),
-          'label' => $view->label(),
+      foreach ($allowed_displays as $display_name => $display_label) {
+        $info['displays'][$allowed_views_keys[$i]][] = [
+          'value' => $display_name,
+          'label' => $display_label,
         ];
       }
     }

--- a/src/Plugin/Field/ReactParagraphsFields/View.php
+++ b/src/Plugin/Field/ReactParagraphsFields/View.php
@@ -51,33 +51,41 @@ class View extends ReactParagraphsFieldsBase {
    */
   public function getFieldInfo(array $field_element, FieldConfigInterface $field_config) {
     $info = parent::getFieldInfo($field_element, $field_config);
-    $info['views'] = [];
     $info['displays'] = [];
-    $widget = $field_element['widget'][0];
-    unset($widget['target_id']['#options']['_none']);
+    $info['views'] = [];
 
-    $allowed_views_keys = array_keys($widget['target_id']['#options']);
-    $allowed_views_values = array_values($widget['target_id']['#options']);
-    $allowed_displays = $widget['display_id']['#options'];
+    $view_storage = $this->entityTypeManager->getStorage('view');
+    $view_options = $field_element['widget'][0]['target_id']['#options'];
+    $allowed_displays = array_filter($field_config->getSetting('allowed_display_types'));
 
-    // TODO: Get these default values working.
-    // $info['defaultValue']['views'] = $widget['target_id']['#default_value'];
-    // $info['defaultValue']['displays'] = $widget['display_id']['#default_value'];
+    /** @var \Drupal\views\ViewEntityInterface $view */
+    foreach ($view_storage->loadMultiple(array_keys($view_options)) as $view) {
+      $displays = $view->get('display');
+      $valid_displays = FALSE;
 
-    foreach ($allowed_views_keys as $i => $v) {
-      $info['views'][] = [
-        'value' => $allowed_views_keys[$i],
-        'label' => $allowed_views_values[$i],
-      ];
+      foreach ($displays as $display_id => $display) {
+        // The field only allows certain display modes. Don't allow those
+        // displays from being available to the user.
+        if ($allowed_displays && !in_array($display['display_plugin'], $allowed_displays)) {
+          continue;
+        }
 
-      foreach ($allowed_displays as $display_name => $display_label) {
-        $info['displays'][$allowed_views_keys[$i]][] = [
-          'value' => $display_name,
-          'label' => $display_label,
+        $valid_displays = TRUE;
+        $info['displays'][$view->id()][] = [
+          'value' => $display_id,
+          'label' => $display['display_title'],
+        ];
+      }
+
+      if ($valid_displays) {
+        $info['views'][] = [
+          'value' => $view->id(),
+          'label' => $view->label(),
         ];
       }
     }
 
+    $this->moduleHandler->invokeAll(("react_paragraphs_getfieldinfo_alter", [$field_element, $field_config,  $info]);
     return $info;
   }
 

--- a/src/ReactParagraphsFieldsBase.php
+++ b/src/ReactParagraphsFieldsBase.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\react_paragraphs;
 
+use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Plugin\PluginBase;
 use Drupal\field\FieldConfigInterface;
@@ -15,10 +16,23 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 abstract class ReactParagraphsFieldsBase extends PluginBase implements ContainerFactoryPluginInterface, ReactParagraphsFieldsInterface {
 
   /**
+   * @var \Drupal\Core\Extension\ModuleHandlerInterface
+   */
+  protected $moduleHandler;
+
+  /**
    * {@inheritDoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-    return new static($configuration, $plugin_id, $plugin_definition);
+    return new static($configuration, $plugin_id, $plugin_definition, $container->get('module_handler'));
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, ModuleHandlerInterface $moduleHandler) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->moduleHandler = $moduleHandler;
   }
 
   /**


### PR DESCRIPTION
# NEEDS WORK

# Summary
- Uses the provided altered widget values instead of constructing them from the settings.
- This allows the values to be altered by other modules.

# Review By (Date)
- Thursday, May 14th

# Urgency
- Med/Low

# Steps to Test

1. Do a complete build of acsf-lelandd8 on the D8CORE-1382 branch
2. Do a site install of the soe_profile (default)
3. Create a new basic page and add a news views paragraph
4. Select (news) then see 5 display options in the widget
5. Close that all down and check out this branch
6. Clear cache.
7. Repeat step 3 + 4 but see only two options (cards + list)

# Affected Projects or Products
- SOE + D8CORE
