### PR TITLE
Decode double encoded json array

### DIFF
--- a/react_paragraphs.install
+++ b/react_paragraphs.install
@@ -194,6 +194,11 @@ function react_paragraphs_update_8203(&$sandbox) {
     $rows = [];
     foreach ($entity->get($field_name)->getValue() as $field_item) {
       $field_item['settings'] = json_decode($field_item['settings'], TRUE);
+      // Because the serializer is gone, the settings might be a double encoded
+      // json string, so we will want to check to try and decode it again.
+      if (!is_array($field_item['settings'])) {
+        $field_item['settings'] = json_decode($field_item['settings'], TRUE);
+      }
       $rows[$field_item['settings']['row']][] = $field_item;
     }
 


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- The serializer is gone now, so the settings is a double encoded json (for whatever reason). decode it again if we need to.

# Need Review By (Date)
- asap

# Urgency
- critical

# Steps to Test
1. run the update on an existing site.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
